### PR TITLE
Fix: loading time in images and button placement

### DIFF
--- a/src/components/Home/Carousel.jsx
+++ b/src/components/Home/Carousel.jsx
@@ -17,7 +17,7 @@ export default function Carousels() {
        
             <div className=" md:flex bg-gray-50 dark:bg-black p-10 max-h-max max-w-max md:h-[70vh] md:w-[70vw] dark:border-2 dark:border-white">
                 <div className="img md:w-[150vw] md:h-[30vw] my-auto">
-                    <img src="./Exersise.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" />
+                    <img src="./Exersise.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" loading="lazy"/>
                 </div>
                 <div className="p-4 border-spacing-2 border-black text-left">
                     <h2 className="text-lg font-semibold m-2 text-gray-400">Sports and Life</h2>
@@ -35,7 +35,7 @@ export default function Carousels() {
 
             <div className="md:flex bg-gray-50 dark:bg-black md:h-[65vh] md:w-[70vw]  p-4 max-h-max max-w-max dark:border-2 dark:border-white">
                 <div className="img md:w-[150vw] md:h-[30vw] my-auto">
-                    <img src="./Health.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" />
+                    <img src="./Health.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" loading="lazy"/>
                 </div>
                 <div className="p-4 border-spacing-2 border-black text-left">
                     <h2 className="text-lg font-semibold m-2 text-gray-400">Healthy Life and Food</h2>
@@ -53,7 +53,7 @@ export default function Carousels() {
 
             <div className="md:flex bg-gray-50 dark:bg-black p-4 max-h-max max-w-max md:h-[65vh] md:w-[70vw] dark:border-2 dark:border-white">
                 <div className="img md:w-[150vw] md:h-[30vw] my-auto">
-                    <img src="./Tech-2.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" />
+                    <img src="./Tech-2.jpg" className="w-full h-[85%] object-cover rounded-lg" alt="Exercise" loading="lazy"/>
                 </div>
                 <div className="p-4 border-spacing-2 border-black text-left">
                     <h2 className="text-lg font-semibold m-2 text-gray-400">Technology</h2>

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -144,14 +144,14 @@ export default function Home() {
               {
               //  TODO: Logo is not changing when switching to dark or light mode instantly but when you take a refresh of your browser it will change according to dark or light theme
               }
-              <img class="mx-auto h-12" src={`${userTheme==="dark"?"../../../public/Logo.png":"../../../public/Logo d.png"}`} alt="" />
+              <img class="mx-auto h-12" src={`${userTheme==="dark"?"../../../public/Logo.png":"../../../public/Logo d.png"}`} alt="company-logo" loading="lazy"/>
               <figure class="mt-10">
                 <blockquote class="text-center text-xl font-semibold leading-8 text-gray-900 dark:text-white sm:text-2xl sm:leading-9">
                   <p><span className="text-4xl text-orange-500">“</span>Explore exciting stories and learn new things with us! Dive into a world of discovery and inspiration. Join our community where we love to share cool stuff. Start your adventure now!<span className="text-4xl text-orange-500">”</span></p>
                 </blockquote>
                 <div className="flex flex-wrap justify-center gap-10">
                   <figcaption class="mt-10">
-                    <img class="mx-auto h-10 w-10 rounded-full" src="https://avatars.githubusercontent.com/u/81561733?s=400&u=f79ed79220505ff06754e9c5097a3608b77c8574&v=4" alt="" />
+                    <img class="mx-auto h-10 w-10 rounded-full" src="https://avatars.githubusercontent.com/u/81561733?s=400&u=f79ed79220505ff06754e9c5097a3608b77c8574&v=4" alt="CEO" loading="lazy"/>
                     <div class="mt-4 flex items-center justify-center space-x-3 text-base">
                       <div class="font-semibold text-gray-900 dark:text-white">Sagar Singh</div>
                       <svg viewBox="0 0 2 2" width="3" height="3" aria-hidden="true" class="fill-gray-900 dark:fill-white">
@@ -161,7 +161,7 @@ export default function Home() {
                     </div>
                   </figcaption>
                   <figcaption class="mt-10">
-                    <img class="mx-auto h-10 w-10 rounded-full" src="https://avatars.githubusercontent.com/u/142565220?v=4" alt="" />
+                    <img class="mx-auto h-10 w-10 rounded-full" src="https://avatars.githubusercontent.com/u/142565220?v=4" alt="CEO" loading="lazy"/>
                     <div class="mt-4 flex items-center justify-center space-x-3 text-base">
                       <div class="font-semibold text-gray-900 dark:text-white">Manendra Verma</div>
                       <svg viewBox="0 0 2 2" width="3" height="3" aria-hidden="true" class="fill-gray-900 dark:fill-white">

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -10,7 +10,7 @@ export default function Footer() {
         <div className="container mx-auto flex flex-wrap justify-between">
           {/* Footer Top Section */}
           <div className="w-full sm:w-1/2 md:w-1/4 px-4 mb-4">
-            <li className="block my-4"><img className='h-10' src="../Logo.png" alt="logo" /></li>
+            <li className="block my-4"><img className='h-10' src="../Logo.png" alt="logo" loading="lazy"/></li>
             <p className="text-sm"> Explore, connect, and be inspired on our blog, where every post unfolds a new chapter in the journey of curiosity. </p>
           </div>
 

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -100,7 +100,7 @@ export default function Navbar() {
         <div className=' flex flex-col justify-between md:flex-row md:justify-between md:max-w-6xl md:mx-auto'>
           <div className='img flex items-center'>
             <NavLink to={"/"}>
-              <img className='h-7 max-w-max' src={userTheme === "dark" ? "../Logo.png" : "../Logo d.png"} alt="logo" />
+              <img className='h-7 max-w-max' src={userTheme === "dark" ? "../Logo.png" : "../Logo d.png"} alt="companylogo" loading="lazy"/>
             </NavLink>
           </div>
 

--- a/src/components/layout/Otheruser.jsx
+++ b/src/components/layout/Otheruser.jsx
@@ -38,7 +38,7 @@ export default function Otheruser(props) {
                     <div className='relative w-[30vw]'>
                         <div className='absolute z-0 rounded-xl w-[33vw] h-[45vh] bg-orange-500 rotate-[55deg] top-[10vh] right-[5vh]'>F</div>
                         <div className='img relative z-10 h-[30vh] w-[15vw] mt-12 rounded-full border-2 m-5 ml-10 bg-white overflow-hidden'>
-                            {avatar ? <img src={avatar} alt="profile" className='w-full h-full object-cover' /> : <FaUserSecret size="5em" className='text-black' />}
+                            {avatar ? <img src={avatar} alt="profile" className='w-full h-full object-cover' loading="lazy"/> : <FaUserSecret size="5em" className='text-black' />}
                         </div>
                         <div className='img relative z-10 text-white font-bold'>
                             <h1 className='text-2xl text-center font-semibold'>{name ? name : 'USER'}</h1>
@@ -48,7 +48,7 @@ export default function Otheruser(props) {
                             <div className='location flex justify-center gap-2 mt-2'>
                                 <h3 className='text-sm text-center text-gray-100 font-semibold inline'>{location ? location.country : "Mirzapur"}
                                 </h3>
-                                <img className='rounded-full inline h-[20px]' src={`${avatar}`} alt="" srcset="" />
+                                <img className='rounded-full inline h-[20px]' src={`${avatar}`} alt="user" loading="lazy"/>
                             </div>
                         </div>
                     </div>

--- a/src/components/layout/UserPost.jsx
+++ b/src/components/layout/UserPost.jsx
@@ -77,7 +77,7 @@ function UserPost({ $id, title, featuredImage, name, content }) {
 
                     </div>
                     <div className='p-5'>
-                        <img className="w-[40rem] mx-auto h-full object-cover rounded-lg bg-white" src={appwriteService.getFilePreview(featuredImage)} alt="img" />
+                        <img className="w-[40rem] mx-auto h-full object-cover rounded-lg bg-white" src={appwriteService.getFilePreview(featuredImage)} alt="img" loading="lazy"/>
                     </div>
                 </div>
 

--- a/src/components/pages/Post.jsx
+++ b/src/components/pages/Post.jsx
@@ -13,6 +13,8 @@ import { FaArrowLeftLong } from "react-icons/fa6";
 import LoadingComponent from "../layout/Loader";
 import Profile from "./userProfile";
 import Otheruser from "../layout/Otheruser";
+import { CiEdit } from "react-icons/ci";
+import { AiOutlineDelete } from "react-icons/ai";
 
 
 export default function Post() {
@@ -21,6 +23,7 @@ export default function Post() {
     const { slug } = useParams();
     const navigate = useNavigate();
     const [refresh, setRefresh] = useState(false);
+    const [isMobile, setIsMobile] = useState(false);        // For mobile view
 
     const userData = useSelector((state) => state.auth.userData);
     const [comments, setComments] = useState([]);
@@ -89,6 +92,19 @@ export default function Post() {
         setProfile(!profile);
     };
 
+    
+// For mobile view
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+    handleResize(); 
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
     return post ? (
         <div>
             {isContentLoaded ? (
@@ -102,7 +118,7 @@ export default function Post() {
                                         <FaUserCircle className="w-full h-full object-cover dark:text-black" />
                                     </div>
 
-                                    <div className="absolute top-1/4 left-[22%] shadow-xl border-2">
+                                    <div className="absolute top-1/4 left-[22%] shadow-xl">
                                         {profile && (
                                             <div className="fixed z-[20]">
                                                 <Otheruser userid={post.userid} />
@@ -127,17 +143,22 @@ export default function Post() {
                                         src={appwriteService.getFilePreview(post.featuredImage)}
                                         alt={post.title}
                                         className="rounded-xl"
+                                        loading="lazy"
                                     />
 
                                     {isAuthor && (
-                                        <div className="absolute right-6 top-6">
+                                        <div className={`absolute ${isMobile ? 'right-2 top-[-15vw]' : 'right-6 top-6'}`}>
                                             <Link to={`/edit-post/${post.$id}`}>
-                                                <Button bgColor="bg-green-500" className="mr-3">
-                                                    Edit
+                                                <Button bgColor="bg-orange-500" className={`mr-3 ${isMobile ? "bg-transparent" : ""}`}>
+                                                    {
+                                                        isMobile ? <CiEdit className='inline text-2xl hover:scale-110 text-gray-600 dark:text-white' /> : "Edit"
+                                                    }
                                                 </Button>
                                             </Link>
-                                            <Button bgColor="bg-red-500" onClick={deletePost}>
-                                                Delete
+                                            <Button bgColor="bg-red-500" className={`${isMobile ? "bg-transparent" : ""}`} onClick={deletePost}>
+                                                    {
+                                                        isMobile ? <AiOutlineDelete className='inline text-2xl hover:scale-110 text-gray-600 dark:text-white' /> : "Delete"
+                                                    }
                                             </Button>
                                         </div>
                                     )}

--- a/src/components/pages/userProfile.jsx
+++ b/src/components/pages/userProfile.jsx
@@ -99,7 +99,7 @@ export default function Profile() {
 
                         <div className='profile-img flex justify-center items-center gap-3'>
                             <div className='img h-[100px] w-[100px] md:h-[25vh] md:w-[13vw] md:mt-12 rounded-full border-2 md:m-5 md:ml-10 bg-white overflow-hidden '>
-                                {avatar ? <img src={avatar} alt="profile" className='w-full h-full object-cover' /> : <FaUserSecret size="5em" className='text-black' />}
+                                {avatar ? <img src={avatar} alt="profile" className='w-full h-full object-cover' loading="lazy" /> : <FaUserSecret size="5em" className='text-black' />}
                             </div>
                                 <div className='flex flex-col gap-0 '>
                                 <h1 className='text-2xl md:hidden md:text-5xl text-center font-semibold'>{name ? name : 'USER'}</h1>
@@ -124,7 +124,7 @@ export default function Profile() {
                                     <div className='location flex justify-center gap-2 mt-1 md:mt-0'>
                                         <h3 className='text-sm text-center text-gray-500 font-semibold inline'>{location ? location.country : "Mirzapur"}
                                         </h3>
-                                        <img className='rounded-full inline h-[20px]' src={`${avatar}`} alt="" srcset="" />
+                                        <img className='rounded-full inline h-[20px]' src={`${avatar}`} alt="avatar" loading="lazy"/>
                                     </div>
                                 </div>
 

--- a/src/components/registration/ResetPassword.jsx
+++ b/src/components/registration/ResetPassword.jsx
@@ -45,7 +45,7 @@ function ResetPassword() {
         <>
             <div className='flex justify-center gap-10 bg-gray-50 dark:bg-gray-900 h-[90vh] items-center'>
                 <div className='p-3'>
-                    <img className='h-[60vh]' src="./reset.svg" alt="" srcset="" />
+                    <img className='h-[60vh]' src="./reset.svg" alt="illustration" loading="lazy"/>
                 </div>
                 {secret && userId ?
                     <div className='h-[50vh] w-[25vw] flex flex-col justify-center'>


### PR DESCRIPTION
fixes: #49 

***Description***
Pages take more to load because of images.
Fix: Reduce The loading time of images using lazy loading

***Description***
issue: On mobile screen for small posts the icon cover half the post which make inconvenience for user.

**frist its look like this**
![image](https://github.com/SAGARSINGH-1/CodeAndBlog/assets/142565220/c03484d6-1382-43b4-b716-fbbd11684084)

**Now its look like this**
![Screenshot 2024-02-06 194538](https://github.com/SAGARSINGH-1/CodeAndBlog/assets/142565220/7d745f18-da76-401e-ac65-e0c774d2ff53)

