### PR TITLE
Fix: Only the intended user can edit the post

### DIFF
--- a/src/components/pages/Post.jsx
+++ b/src/components/pages/Post.jsx
@@ -29,7 +29,7 @@ export default function Post() {
     const [comments, setComments] = useState([]);
     useEffect(() => {
         if (post && userData) {
-            setIsAuthor(userData ? post.name === userData.userData.name : false);
+            setIsAuthor(userData ? post.userid === userData.userData.userid : false);
             refreshcomment();
         }
     }, [post, userData]);

--- a/src/components/registration/Login.jsx
+++ b/src/components/registration/Login.jsx
@@ -21,15 +21,14 @@ export default function Login() {
     try {
       const session = await authService.login(data)
       if (session) {
-        const userData = await authService.getCurrentUser()
-        if (userData) dispatch(authLogin(userData));
+        const userData = await authService.getCurrentUser()            
+        if (userData) dispatch(authLogin(userData));          
         navigate("/")
       }
     } catch (error) {
       setError(error.message)
     }
   }
-
 
   // top Loader
   const [isContentLoaded, setContentLoaded] = useState(false);


### PR DESCRIPTION
#53 

**Description**
If the two different user has same username, then they both able to edit the post uploaded by the user. This led to security and privacy issue.

**Fixed**
Use the user id for comparison between same user or different user who can edit the post 